### PR TITLE
feat: Registrations モジュール実装

### DIFF
--- a/src/EventRegistration.Web/Adapters/EventCapacityCheckerAdapter.cs
+++ b/src/EventRegistration.Web/Adapters/EventCapacityCheckerAdapter.cs
@@ -1,0 +1,28 @@
+using EventRegistration.Events.Infrastructure.Persistence;
+using EventRegistration.Registrations.Application.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventRegistration.Web.Adapters;
+
+/// <summary>
+/// EventsDbContext を使用して IEventCapacityChecker を実装する反腐敗層アダプター。
+/// Registrations モジュールから Events モジュールへの間接アクセスを仲介する。
+/// </summary>
+public sealed class EventCapacityCheckerAdapter(EventsDbContext eventsDbContext) : IEventCapacityChecker
+{
+    public async Task<EventCapacityInfo?> GetEventCapacityInfoAsync(
+        Guid eventId,
+        CancellationToken cancellationToken = default)
+    {
+        var ev = await eventsDbContext.Events
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == eventId, cancellationToken);
+
+        if (ev is null)
+        {
+            return null;
+        }
+
+        return new EventCapacityInfo(ev.Id, ev.Name, ev.Capacity);
+    }
+}

--- a/src/EventRegistration.Web/Components/Pages/Events/EventCreate.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/EventCreate.razor
@@ -1,0 +1,113 @@
+@page "/events/create"
+
+<PageTitle>イベント作成</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">新しいイベントの作成</MudText>
+
+<MudPaper Class="pa-4" MaxWidth="600px">
+    <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="createEvent">
+        <DataAnnotationsValidator />
+
+        <MudTextField @bind-Value="_model.Name"
+                      Label="イベント名"
+                      Required="true"
+                      RequiredError="イベント名は必須です"
+                      Class="mb-4" />
+
+        <MudDatePicker @bind-Date="_model.ScheduledDate"
+                       Label="開催日"
+                       Required="true"
+                       RequiredError="開催日は必須です"
+                       Class="mb-4" />
+
+        <MudTimePicker @bind-Time="_model.ScheduledTime"
+                       Label="開催時間"
+                       Required="true"
+                       RequiredError="開催時間は必須です"
+                       Class="mb-4" />
+
+        <MudNumericField @bind-Value="_model.Capacity"
+                         Label="定員"
+                         Required="true"
+                         RequiredError="定員は必須です"
+                         Min="1"
+                         Class="mb-4" />
+
+        <MudTextField @bind-Value="_model.Description"
+                      Label="説明"
+                      Lines="3"
+                      Class="mb-4" />
+
+        @if (!string.IsNullOrEmpty(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-4">@_errorMessage</MudAlert>
+        }
+
+        <div class="d-flex gap-2">
+            <MudButton ButtonType="ButtonType.Submit"
+                       Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Disabled="_submitting">
+                @if (_submitting)
+                {
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                }
+                保存
+            </MudButton>
+            <MudButton Variant="Variant.Text" Href="/events">キャンセル</MudButton>
+        </div>
+    </EditForm>
+</MudPaper>
+
+@code {
+    [Inject] private CreateEventUseCase CreateEventUseCase { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    private readonly EventCreateModel _model = new();
+    private bool _submitting;
+    private string? _errorMessage;
+
+    private async Task HandleSubmit()
+    {
+        _submitting = true;
+        _errorMessage = null;
+
+        try
+        {
+            if (_model.ScheduledDate is null || _model.ScheduledTime is null)
+            {
+                _errorMessage = "開催日時は必須です。";
+                return;
+            }
+
+            var scheduledAt = new DateTimeOffset(
+                _model.ScheduledDate.Value.Add(_model.ScheduledTime.Value),
+                TimeZoneInfo.Local.GetUtcOffset(DateTime.Now));
+
+            var ev = await CreateEventUseCase.ExecuteAsync(
+                _model.Name!,
+                _model.Description,
+                scheduledAt,
+                _model.Capacity);
+
+            NavigationManager.NavigateTo($"/events/{ev.Id}");
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+        }
+        finally
+        {
+            _submitting = false;
+        }
+    }
+
+    private sealed class EventCreateModel
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public DateTime? ScheduledDate { get; set; } = DateTime.Today.AddDays(7);
+        public TimeSpan? ScheduledTime { get; set; } = new(18, 0, 0);
+        public int Capacity { get; set; } = 10;
+    }
+}

--- a/src/EventRegistration.Web/Components/Pages/Events/EventDetail.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/EventDetail.razor
@@ -1,0 +1,91 @@
+@page "/events/{EventId:guid}"
+
+<PageTitle>イベント詳細</PageTitle>
+
+@if (_loading)
+{
+    <MudProgressCircular Indeterminate="true" />
+}
+else if (_event is null)
+{
+    <MudAlert Severity="Severity.Warning">イベントが見つかりません。</MudAlert>
+    <MudButton Variant="Variant.Text" Href="/events" Class="mt-4">一覧に戻る</MudButton>
+}
+else
+{
+    <MudButton Variant="Variant.Text" Href="/events" StartIcon="@Icons.Material.Filled.ArrowBack" Class="mb-4">
+        一覧に戻る
+    </MudButton>
+
+    <MudText Typo="Typo.h4" Class="mb-4">@_event.Name</MudText>
+
+    <MudPaper Class="pa-4 mb-4">
+        <MudGrid>
+            <MudItem xs="12" sm="6">
+                <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">開催日時</MudText>
+                <MudText>@_event.ScheduledAt.LocalDateTime.ToString("yyyy/MM/dd HH:mm")</MudText>
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">定員</MudText>
+                <MudText>@_event.Capacity 名（残り @_remainingSlots 枠）</MudText>
+            </MudItem>
+            @if (!string.IsNullOrWhiteSpace(_event.Description))
+            {
+                <MudItem xs="12">
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">説明</MudText>
+                    <MudText>@_event.Description</MudText>
+                </MudItem>
+            }
+        </MudGrid>
+    </MudPaper>
+
+    <MudGrid>
+        <MudItem xs="12" md="5">
+            <MudText Typo="Typo.h5" Class="mb-2">参加登録</MudText>
+            <RegistrationForm EventId="EventId" OnRegistered="HandleRegistered" />
+        </MudItem>
+        <MudItem xs="12" md="7">
+            <MudText Typo="Typo.h5" Class="mb-2">参加者一覧</MudText>
+            <ParticipantList EventId="EventId" @ref="_participantList" />
+        </MudItem>
+    </MudGrid>
+}
+
+@code {
+    [Parameter] public Guid EventId { get; set; }
+
+    [Inject] private GetEventByIdUseCase GetEventByIdUseCase { get; set; } = default!;
+    [Inject] private GetRegistrationsByEventUseCase GetRegistrationsUseCase { get; set; } = default!;
+
+    private Event? _event;
+    private bool _loading = true;
+    private int _remainingSlots;
+    private ParticipantList? _participantList;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataAsync();
+        _loading = false;
+    }
+
+    private async Task LoadDataAsync()
+    {
+        _event = await GetEventByIdUseCase.ExecuteAsync(EventId);
+        if (_event is not null)
+        {
+            var registrations = await GetRegistrationsUseCase.ExecuteAsync(EventId);
+            var confirmedCount = registrations.Count(r => r.Status == RegistrationStatus.Confirmed);
+            _remainingSlots = Math.Max(0, _event.Capacity - confirmedCount);
+        }
+    }
+
+    private async Task HandleRegistered()
+    {
+        await LoadDataAsync();
+        if (_participantList is not null)
+        {
+            await _participantList.RefreshAsync();
+        }
+        StateHasChanged();
+    }
+}

--- a/src/EventRegistration.Web/Components/Pages/Events/EventList.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/EventList.razor
@@ -1,0 +1,73 @@
+@page "/events"
+
+<PageTitle>イベント一覧</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">イベント一覧</MudText>
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/events/create" Class="mb-4">
+    新しいイベントを作成
+</MudButton>
+
+@if (_loading)
+{
+    <MudProgressCircular Indeterminate="true" />
+}
+else if (_events is null || _events.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">イベントがまだ登録されていません。</MudAlert>
+}
+else
+{
+    <MudGrid>
+        @foreach (var ev in _events)
+        {
+            <MudItem xs="12" sm="6" md="4">
+                <MudCard Class="cursor-pointer" @onclick="() => NavigateToDetail(ev.Id)">
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">@ev.Name</MudText>
+                        </CardHeaderContent>
+                        <CardHeaderActions>
+                            <MudIcon Icon="@Icons.Material.Filled.Event" />
+                        </CardHeaderActions>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText Typo="Typo.body2" Class="mb-2">
+                            <MudIcon Icon="@Icons.Material.Filled.CalendarToday" Size="Size.Small" Class="mr-1" />
+                            @ev.ScheduledAt.LocalDateTime.ToString("yyyy/MM/dd HH:mm")
+                        </MudText>
+                        <MudText Typo="Typo.body2" Class="mb-2">
+                            <MudIcon Icon="@Icons.Material.Filled.People" Size="Size.Small" Class="mr-1" />
+                            定員: @ev.Capacity 名
+                        </MudText>
+                        @if (!string.IsNullOrWhiteSpace(ev.Description))
+                        {
+                            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                                @(ev.Description.Length > 100 ? ev.Description[..100] + "..." : ev.Description)
+                            </MudText>
+                        }
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+    </MudGrid>
+}
+
+@code {
+    [Inject] private GetAllEventsUseCase GetAllEventsUseCase { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    private IReadOnlyList<Event>? _events;
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _events = await GetAllEventsUseCase.ExecuteAsync();
+        _loading = false;
+    }
+
+    private void NavigateToDetail(Guid id)
+    {
+        NavigationManager.NavigateTo($"/events/{id}");
+    }
+}

--- a/src/EventRegistration.Web/Components/Pages/Events/ParticipantList.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/ParticipantList.razor
@@ -1,0 +1,142 @@
+@inject IDialogService DialogService
+
+@if (_loading)
+{
+    <MudProgressCircular Indeterminate="true" />
+}
+else if (_registrations is null || _registrations.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">まだ参加者がいません。</MudAlert>
+}
+else
+{
+    if (Confirmed.Count > 0)
+    {
+        <MudText Typo="Typo.h6" Class="mb-2">参加確定（@Confirmed.Count 名）</MudText>
+        <MudTable Items="Confirmed" Dense="true" Hover="true" Class="mb-4">
+            <HeaderContent>
+                <MudTh>参加者名</MudTh>
+                <MudTh>メールアドレス</MudTh>
+                <MudTh>登録日時</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.ParticipantName</MudTd>
+                <MudTd>@context.Email</MudTd>
+                <MudTd>@context.RegisteredAt.LocalDateTime.ToString("yyyy/MM/dd HH:mm")</MudTd>
+                <MudTd>
+                    <MudButton Size="Size.Small"
+                               Variant="Variant.Text"
+                               Color="Color.Error"
+                               OnClick="() => HandleCancel(context)">
+                        キャンセル
+                    </MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+
+    if (WaitListed.Count > 0)
+    {
+        <MudText Typo="Typo.h6" Class="mb-2">キャンセル待ち（@WaitListed.Count 名）</MudText>
+        <MudTable Items="WaitListed" Dense="true" Hover="true">
+            <HeaderContent>
+                <MudTh>参加者名</MudTh>
+                <MudTh>メールアドレス</MudTh>
+                <MudTh>登録日時</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.ParticipantName</MudTd>
+                <MudTd>@context.Email</MudTd>
+                <MudTd>@context.RegisteredAt.LocalDateTime.ToString("yyyy/MM/dd HH:mm")</MudTd>
+                <MudTd>
+                    <MudButton Size="Size.Small"
+                               Variant="Variant.Text"
+                               Color="Color.Error"
+                               OnClick="() => HandleCancel(context)">
+                        キャンセル
+                    </MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+}
+
+@if (!string.IsNullOrEmpty(_message))
+{
+    <MudAlert Severity="@_severity" Class="mt-2">@_message</MudAlert>
+}
+
+@code {
+    [Parameter] public Guid EventId { get; set; }
+    [Parameter] public EventCallback OnCancelled { get; set; }
+
+    [Inject] private GetRegistrationsByEventUseCase GetRegistrationsUseCase { get; set; } = default!;
+    [Inject] private CancelRegistrationUseCase CancelUseCase { get; set; } = default!;
+
+    private IReadOnlyList<Registration>? _registrations;
+    private bool _loading = true;
+    private string? _message;
+    private Severity _severity;
+
+    private List<Registration> Confirmed =>
+        _registrations?.Where(r => r.Status == RegistrationStatus.Confirmed).ToList() ?? [];
+
+    private List<Registration> WaitListed =>
+        _registrations?.Where(r => r.Status == RegistrationStatus.WaitListed).ToList() ?? [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+        _loading = false;
+    }
+
+    public async Task RefreshAsync()
+    {
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    private async Task LoadAsync()
+    {
+        _registrations = await GetRegistrationsUseCase.ExecuteAsync(EventId);
+    }
+
+    private async Task HandleCancel(Registration registration)
+    {
+        var result = await DialogService.ShowMessageBoxAsync(
+            "キャンセル確認",
+            $"{registration.ParticipantName} さんの参加登録をキャンセルしますか？",
+            yesText: "キャンセルする",
+            cancelText: "戻る");
+
+        if (result != true) return;
+
+        try
+        {
+            var cancelResult = await CancelUseCase.ExecuteAsync(registration.Id);
+            if (cancelResult.IsSuccess)
+            {
+                _message = "キャンセルしました。";
+                _severity = Severity.Info;
+                if (cancelResult.PromotedRegistration is not null)
+                {
+                    _message += $" {cancelResult.PromotedRegistration.ParticipantName} さんが参加確定に繰り上がりました。";
+                }
+                await LoadAsync();
+                await OnCancelled.InvokeAsync();
+            }
+            else
+            {
+                _message = cancelResult.ErrorMessage;
+                _severity = Severity.Error;
+            }
+        }
+        catch (Exception ex)
+        {
+            _message = ex.Message;
+            _severity = Severity.Error;
+        }
+    }
+}

--- a/src/EventRegistration.Web/Components/Pages/Events/RegistrationForm.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/RegistrationForm.razor
@@ -1,0 +1,95 @@
+<MudPaper Class="pa-4">
+    <EditForm Model="_model" OnValidSubmit="HandleSubmit" FormName="registerParticipant">
+        <DataAnnotationsValidator />
+
+        <MudTextField @bind-Value="_model.ParticipantName"
+                      Label="参加者名"
+                      Required="true"
+                      RequiredError="参加者名は必須です"
+                      Class="mb-3" />
+
+        <MudTextField @bind-Value="_model.Email"
+                      Label="メールアドレス"
+                      Required="true"
+                      RequiredError="メールアドレスは必須です"
+                      InputType="InputType.Email"
+                      Class="mb-3" />
+
+        @if (!string.IsNullOrEmpty(_message))
+        {
+            <MudAlert Severity="@_severity" Class="mb-3">@_message</MudAlert>
+        }
+
+        <MudButton ButtonType="ButtonType.Submit"
+                   Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Disabled="_submitting"
+                   FullWidth="true">
+            @if (_submitting)
+            {
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+            }
+            参加登録
+        </MudButton>
+    </EditForm>
+</MudPaper>
+
+@code {
+    [Parameter] public Guid EventId { get; set; }
+    [Parameter] public EventCallback OnRegistered { get; set; }
+
+    [Inject] private RegisterParticipantUseCase RegisterUseCase { get; set; } = default!;
+
+    private readonly RegistrationFormModel _model = new();
+    private bool _submitting;
+    private string? _message;
+    private Severity _severity;
+
+    private async Task HandleSubmit()
+    {
+        _submitting = true;
+        _message = null;
+
+        try
+        {
+            var result = await RegisterUseCase.ExecuteAsync(
+                EventId,
+                _model.ParticipantName!,
+                _model.Email!);
+
+            if (result.IsSuccess)
+            {
+                var statusText = result.Registration.Status == RegistrationStatus.Confirmed
+                    ? "参加確定"
+                    : "キャンセル待ち";
+                _message = $"登録が完了しました（{statusText}）。";
+                _severity = result.Registration.Status == RegistrationStatus.Confirmed
+                    ? Severity.Success
+                    : Severity.Warning;
+                _model.ParticipantName = null;
+                _model.Email = null;
+                await OnRegistered.InvokeAsync();
+            }
+            else
+            {
+                _message = result.ErrorMessage;
+                _severity = Severity.Error;
+            }
+        }
+        catch (Exception ex)
+        {
+            _message = ex.Message;
+            _severity = Severity.Error;
+        }
+        finally
+        {
+            _submitting = false;
+        }
+    }
+
+    private sealed class RegistrationFormModel
+    {
+        public string? ParticipantName { get; set; }
+        public string? Email { get; set; }
+    }
+}

--- a/src/EventRegistration.Web/Components/_Imports.razor
+++ b/src/EventRegistration.Web/Components/_Imports.razor
@@ -13,3 +13,7 @@
 @using EventRegistration.SharedKernel.Application.Navigation
 @using EventRegistration.Web.Shell.Navigation
 @using EventRegistration.Web.Shell.Theme
+@using EventRegistration.Events.Domain
+@using EventRegistration.Events.Application.UseCases
+@using EventRegistration.Registrations.Domain
+@using EventRegistration.Registrations.Application.UseCases

--- a/src/EventRegistration.Web/Program.cs
+++ b/src/EventRegistration.Web/Program.cs
@@ -1,5 +1,9 @@
 using EventRegistration.Events.Application.Navigation;
+using EventRegistration.Events.Infrastructure;
 using EventRegistration.Registrations.Application.Navigation;
+using EventRegistration.Registrations.Application.Services;
+using EventRegistration.Registrations.Infrastructure;
+using EventRegistration.Web.Adapters;
 using EventRegistration.Web.Components;
 using MudBlazor.Services;
 
@@ -13,6 +17,13 @@ builder.Services.AddMudServices();
 // 各モジュールが提供するナビゲーション項目を登録
 builder.Services.AddEventsModuleNavigation();
 builder.Services.AddRegistrationsModuleNavigation();
+
+// 各モジュールの Infrastructure サービスを登録
+builder.Services.AddEventsModuleInfrastructure();
+builder.Services.AddRegistrationsModuleInfrastructure();
+
+// モジュール間アダプターを登録
+builder.Services.AddScoped<IEventCapacityChecker, EventCapacityCheckerAdapter>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()

--- a/src/Modules/Events/EventRegistration.Events.Application/Navigation/EventsNavigationExtensions.cs
+++ b/src/Modules/Events/EventRegistration.Events.Application/Navigation/EventsNavigationExtensions.cs
@@ -15,7 +15,7 @@ public static class EventsNavigationExtensions
     {
         services.AddSingleton<INavigationItem>(new NavigationItem(
             Title: "イベント管理",
-            Href: "/", // プレースホルダー (将来 /events 等に差し替え)
+            Href: "/events",
             Icon: "Event",
             Group: "イベント",
             Order: 100,

--- a/src/Modules/Events/EventRegistration.Events.Application/Repositories/IEventRepository.cs
+++ b/src/Modules/Events/EventRegistration.Events.Application/Repositories/IEventRepository.cs
@@ -1,0 +1,13 @@
+using EventRegistration.Events.Domain;
+
+namespace EventRegistration.Events.Application.Repositories;
+
+/// <summary>
+/// Event エンティティのリポジトリ抽象。
+/// </summary>
+public interface IEventRepository
+{
+    Task<Event?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Event>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task AddAsync(Event ev, CancellationToken cancellationToken = default);
+}

--- a/src/Modules/Events/EventRegistration.Events.Application/UseCases/CreateEventUseCase.cs
+++ b/src/Modules/Events/EventRegistration.Events.Application/UseCases/CreateEventUseCase.cs
@@ -1,0 +1,22 @@
+using EventRegistration.Events.Application.Repositories;
+using EventRegistration.Events.Domain;
+
+namespace EventRegistration.Events.Application.UseCases;
+
+/// <summary>
+/// 新しいイベントを作成するユースケース。
+/// </summary>
+public sealed class CreateEventUseCase(IEventRepository eventRepository)
+{
+    public async Task<Event> ExecuteAsync(
+        string name,
+        string? description,
+        DateTimeOffset scheduledAt,
+        int capacity,
+        CancellationToken cancellationToken = default)
+    {
+        var ev = Event.Create(name, description, scheduledAt, capacity);
+        await eventRepository.AddAsync(ev, cancellationToken);
+        return ev;
+    }
+}

--- a/src/Modules/Events/EventRegistration.Events.Application/UseCases/GetAllEventsUseCase.cs
+++ b/src/Modules/Events/EventRegistration.Events.Application/UseCases/GetAllEventsUseCase.cs
@@ -1,0 +1,15 @@
+using EventRegistration.Events.Application.Repositories;
+using EventRegistration.Events.Domain;
+
+namespace EventRegistration.Events.Application.UseCases;
+
+/// <summary>
+/// すべてのイベントを取得するユースケース。
+/// </summary>
+public sealed class GetAllEventsUseCase(IEventRepository eventRepository)
+{
+    public async Task<IReadOnlyList<Event>> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        return await eventRepository.GetAllAsync(cancellationToken);
+    }
+}

--- a/src/Modules/Events/EventRegistration.Events.Application/UseCases/GetEventByIdUseCase.cs
+++ b/src/Modules/Events/EventRegistration.Events.Application/UseCases/GetEventByIdUseCase.cs
@@ -1,0 +1,15 @@
+using EventRegistration.Events.Application.Repositories;
+using EventRegistration.Events.Domain;
+
+namespace EventRegistration.Events.Application.UseCases;
+
+/// <summary>
+/// イベントを ID で取得するユースケース。
+/// </summary>
+public sealed class GetEventByIdUseCase(IEventRepository eventRepository)
+{
+    public async Task<Event?> ExecuteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await eventRepository.GetByIdAsync(id, cancellationToken);
+    }
+}

--- a/src/Modules/Events/EventRegistration.Events.Domain/Event.cs
+++ b/src/Modules/Events/EventRegistration.Events.Domain/Event.cs
@@ -1,0 +1,32 @@
+namespace EventRegistration.Events.Domain;
+
+/// <summary>
+/// イベント情報を表す集約ルート。
+/// </summary>
+public class Event
+{
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+    public DateTimeOffset ScheduledAt { get; private set; }
+    public int Capacity { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    private Event() { }
+
+    public static Event Create(string name, string? description, DateTimeOffset scheduledAt, int capacity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+
+        return new Event
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Description = description,
+            ScheduledAt = scheduledAt,
+            Capacity = capacity,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}

--- a/src/Modules/Events/EventRegistration.Events.Infrastructure/EventRegistration.Events.Infrastructure.csproj
+++ b/src/Modules/Events/EventRegistration.Events.Infrastructure/EventRegistration.Events.Infrastructure.csproj
@@ -5,6 +5,11 @@
     <ProjectReference Include="..\EventRegistration.Events.Domain\EventRegistration.Events.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Modules/Events/EventRegistration.Events.Infrastructure/EventsModuleInfrastructureExtensions.cs
+++ b/src/Modules/Events/EventRegistration.Events.Infrastructure/EventsModuleInfrastructureExtensions.cs
@@ -1,0 +1,29 @@
+using EventRegistration.Events.Application.Repositories;
+using EventRegistration.Events.Application.UseCases;
+using EventRegistration.Events.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventRegistration.Events.Infrastructure;
+
+/// <summary>
+/// Events モジュールの Infrastructure サービスを DI コンテナへ登録する拡張メソッド。
+/// </summary>
+public static class EventsModuleInfrastructureExtensions
+{
+    /// <summary>
+    /// Events モジュールの DbContext、リポジトリ、ユースケースを登録する。
+    /// </summary>
+    public static IServiceCollection AddEventsModuleInfrastructure(this IServiceCollection services)
+    {
+        services.AddDbContext<EventsDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: "Events"));
+
+        services.AddScoped<IEventRepository, EventRepository>();
+        services.AddScoped<CreateEventUseCase>();
+        services.AddScoped<GetEventByIdUseCase>();
+        services.AddScoped<GetAllEventsUseCase>();
+
+        return services;
+    }
+}

--- a/src/Modules/Events/EventRegistration.Events.Infrastructure/Persistence/EventRepository.cs
+++ b/src/Modules/Events/EventRegistration.Events.Infrastructure/Persistence/EventRepository.cs
@@ -1,0 +1,29 @@
+using EventRegistration.Events.Application.Repositories;
+using EventRegistration.Events.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventRegistration.Events.Infrastructure.Persistence;
+
+/// <summary>
+/// IEventRepository の EF Core 実装。
+/// </summary>
+public sealed class EventRepository(EventsDbContext dbContext) : IEventRepository
+{
+    public async Task<Event?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Events.FindAsync([id], cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Event>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Events
+            .OrderByDescending(e => e.ScheduledAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Event ev, CancellationToken cancellationToken = default)
+    {
+        await dbContext.Events.AddAsync(ev, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Modules/Events/EventRegistration.Events.Infrastructure/Persistence/EventsDbContext.cs
+++ b/src/Modules/Events/EventRegistration.Events.Infrastructure/Persistence/EventsDbContext.cs
@@ -1,0 +1,24 @@
+using EventRegistration.Events.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventRegistration.Events.Infrastructure.Persistence;
+
+/// <summary>
+/// Events モジュールの DbContext。
+/// </summary>
+public sealed class EventsDbContext(DbContextOptions<EventsDbContext> options) : DbContext(options)
+{
+    public DbSet<Event> Events => Set<Event>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Event>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired();
+            entity.Property(e => e.ScheduledAt).IsRequired();
+            entity.Property(e => e.Capacity).IsRequired();
+            entity.Property(e => e.CreatedAt).IsRequired();
+        });
+    }
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Application/Repositories/IRegistrationRepository.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Application/Repositories/IRegistrationRepository.cs
@@ -1,0 +1,17 @@
+using EventRegistration.Registrations.Domain;
+
+namespace EventRegistration.Registrations.Application.Repositories;
+
+/// <summary>
+/// Registration エンティティのリポジトリ抽象。
+/// </summary>
+public interface IRegistrationRepository
+{
+    Task<Registration?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Registration>> GetByEventIdAsync(Guid eventId, CancellationToken cancellationToken = default);
+    Task<int> CountConfirmedByEventIdAsync(Guid eventId, CancellationToken cancellationToken = default);
+    Task<bool> HasActiveRegistrationAsync(Guid eventId, string normalizedEmail, CancellationToken cancellationToken = default);
+    Task<Registration?> GetOldestWaitListedAsync(Guid eventId, CancellationToken cancellationToken = default);
+    Task AddAsync(Registration registration, CancellationToken cancellationToken = default);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Application/Services/IEventCapacityChecker.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Application/Services/IEventCapacityChecker.cs
@@ -1,0 +1,19 @@
+namespace EventRegistration.Registrations.Application.Services;
+
+/// <summary>
+/// イベントの定員情報を取得するための反腐敗層インターフェース。
+/// Registrations モジュールが Events モジュールのデータに間接的にアクセスする。
+/// </summary>
+public interface IEventCapacityChecker
+{
+    /// <summary>
+    /// 指定されたイベントの定員情報を取得する。
+    /// </summary>
+    /// <returns>イベントが存在する場合はその情報、存在しない場合は null。</returns>
+    Task<EventCapacityInfo?> GetEventCapacityInfoAsync(Guid eventId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// イベントの定員に関する情報。
+/// </summary>
+public sealed record EventCapacityInfo(Guid EventId, string EventName, int Capacity);

--- a/src/Modules/Registrations/EventRegistration.Registrations.Application/UseCases/CancelRegistrationUseCase.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Application/UseCases/CancelRegistrationUseCase.cs
@@ -1,0 +1,56 @@
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Domain;
+
+namespace EventRegistration.Registrations.Application.UseCases;
+
+/// <summary>
+/// キャンセルの結果。
+/// </summary>
+public sealed record CancelResult(bool IsSuccess, string? ErrorMessage = null, Registration? PromotedRegistration = null)
+{
+    public static CancelResult Success(Registration? promoted = null) => new(true, PromotedRegistration: promoted);
+    public static CancelResult Failure(string errorMessage) => new(false, errorMessage);
+}
+
+/// <summary>
+/// 参加登録をキャンセルするユースケース。
+/// キャンセル待ち繰り上げロジックを含む。
+/// </summary>
+public sealed class CancelRegistrationUseCase(IRegistrationRepository registrationRepository)
+{
+    public async Task<CancelResult> ExecuteAsync(
+        Guid registrationId,
+        CancellationToken cancellationToken = default)
+    {
+        var registration = await registrationRepository.GetByIdAsync(registrationId, cancellationToken);
+        if (registration is null)
+        {
+            return CancelResult.Failure("指定された登録が見つかりません。");
+        }
+
+        if (registration.Status == RegistrationStatus.Cancelled)
+        {
+            return CancelResult.Failure("既にキャンセル済みです。");
+        }
+
+        var wasConfirmed = registration.Status == RegistrationStatus.Confirmed;
+        registration.Cancel();
+
+        // 確定者がキャンセルした場合、キャンセル待ちの先頭を繰り上げ
+        Registration? promoted = null;
+        if (wasConfirmed)
+        {
+            var nextWaitListed = await registrationRepository.GetOldestWaitListedAsync(
+                registration.EventId, cancellationToken);
+
+            if (nextWaitListed is not null)
+            {
+                nextWaitListed.Confirm();
+                promoted = nextWaitListed;
+            }
+        }
+
+        await registrationRepository.SaveChangesAsync(cancellationToken);
+        return CancelResult.Success(promoted);
+    }
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Application/UseCases/GetRegistrationsByEventUseCase.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Application/UseCases/GetRegistrationsByEventUseCase.cs
@@ -1,0 +1,17 @@
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Domain;
+
+namespace EventRegistration.Registrations.Application.UseCases;
+
+/// <summary>
+/// イベントに対する参加登録一覧を取得するユースケース。
+/// </summary>
+public sealed class GetRegistrationsByEventUseCase(IRegistrationRepository registrationRepository)
+{
+    public async Task<IReadOnlyList<Registration>> ExecuteAsync(
+        Guid eventId,
+        CancellationToken cancellationToken = default)
+    {
+        return await registrationRepository.GetByEventIdAsync(eventId, cancellationToken);
+    }
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Application/UseCases/RegisterParticipantUseCase.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Application/UseCases/RegisterParticipantUseCase.cs
@@ -1,0 +1,58 @@
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Application.Services;
+using EventRegistration.Registrations.Domain;
+
+namespace EventRegistration.Registrations.Application.UseCases;
+
+/// <summary>
+/// 参加登録の結果。
+/// </summary>
+public sealed record RegisterResult(Registration Registration, bool IsSuccess, string? ErrorMessage = null)
+{
+    public static RegisterResult Success(Registration registration) => new(registration, true);
+    public static RegisterResult Failure(string errorMessage) => new(null!, false, errorMessage);
+}
+
+/// <summary>
+/// イベントへの参加登録を行うユースケース。
+/// </summary>
+public sealed class RegisterParticipantUseCase(
+    IRegistrationRepository registrationRepository,
+    IEventCapacityChecker eventCapacityChecker)
+{
+    public async Task<RegisterResult> ExecuteAsync(
+        Guid eventId,
+        string participantName,
+        string email,
+        CancellationToken cancellationToken = default)
+    {
+        // イベントの存在確認と定員取得
+        var eventInfo = await eventCapacityChecker.GetEventCapacityInfoAsync(eventId, cancellationToken);
+        if (eventInfo is null)
+        {
+            return RegisterResult.Failure("指定されたイベントが見つかりません。");
+        }
+
+        // メールアドレスを正規化
+        var normalizedEmail = Registration.NormalizeEmail(email);
+
+        // 重複登録チェック（有効な登録が既にある場合は不可）
+        var hasActive = await registrationRepository.HasActiveRegistrationAsync(eventId, normalizedEmail, cancellationToken);
+        if (hasActive)
+        {
+            return RegisterResult.Failure("このメールアドレスでは既に登録済みです。");
+        }
+
+        // 定員チェック: Confirmed 数が定員未満なら Confirmed、以上なら WaitListed
+        var confirmedCount = await registrationRepository.CountConfirmedByEventIdAsync(eventId, cancellationToken);
+        var status = confirmedCount < eventInfo.Capacity
+            ? RegistrationStatus.Confirmed
+            : RegistrationStatus.WaitListed;
+
+        var registration = Registration.Create(eventId, participantName, email, status);
+        await registrationRepository.AddAsync(registration, cancellationToken);
+        await registrationRepository.SaveChangesAsync(cancellationToken);
+
+        return RegisterResult.Success(registration);
+    }
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Domain/Registration.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Domain/Registration.cs
@@ -1,0 +1,70 @@
+namespace EventRegistration.Registrations.Domain;
+
+/// <summary>
+/// 参加登録情報を表す集約ルート。
+/// </summary>
+public class Registration
+{
+    public Guid Id { get; private set; }
+    public Guid EventId { get; private set; }
+    public string ParticipantName { get; private set; } = string.Empty;
+    public string Email { get; private set; } = string.Empty;
+    public RegistrationStatus Status { get; private set; }
+    public DateTimeOffset RegisteredAt { get; private set; }
+    public DateTimeOffset? CancelledAt { get; private set; }
+
+    private Registration() { }
+
+    public static Registration Create(
+        Guid eventId,
+        string participantName,
+        string email,
+        RegistrationStatus status)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(participantName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+
+        return new Registration
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            ParticipantName = participantName.Trim(),
+            Email = NormalizeEmail(email),
+            Status = status,
+            RegisteredAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    /// <summary>
+    /// 登録をキャンセルする。
+    /// </summary>
+    public void Cancel()
+    {
+        if (Status == RegistrationStatus.Cancelled)
+        {
+            throw new InvalidOperationException("既にキャンセル済みです。");
+        }
+
+        Status = RegistrationStatus.Cancelled;
+        CancelledAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// キャンセル待ちから参加確定に繰り上げる。
+    /// </summary>
+    public void Confirm()
+    {
+        if (Status != RegistrationStatus.WaitListed)
+        {
+            throw new InvalidOperationException("キャンセル待ち状態のみ確定に変更できます。");
+        }
+
+        Status = RegistrationStatus.Confirmed;
+    }
+
+    /// <summary>
+    /// メールアドレスを正規化する（トリム＋小文字化）。
+    /// </summary>
+    public static string NormalizeEmail(string email) =>
+        email.Trim().ToLowerInvariant();
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Domain/RegistrationStatus.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Domain/RegistrationStatus.cs
@@ -1,0 +1,16 @@
+namespace EventRegistration.Registrations.Domain;
+
+/// <summary>
+/// 登録状態を表す列挙型。
+/// </summary>
+public enum RegistrationStatus
+{
+    /// <summary>参加確定（定員以内）。</summary>
+    Confirmed,
+
+    /// <summary>キャンセル待ち（定員超過）。</summary>
+    WaitListed,
+
+    /// <summary>キャンセル済み。</summary>
+    Cancelled,
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/EventRegistration.Registrations.Infrastructure.csproj
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/EventRegistration.Registrations.Infrastructure.csproj
@@ -5,6 +5,11 @@
     <ProjectReference Include="..\EventRegistration.Registrations.Domain\EventRegistration.Registrations.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationRepository.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationRepository.cs
@@ -1,0 +1,60 @@
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventRegistration.Registrations.Infrastructure.Persistence;
+
+/// <summary>
+/// IRegistrationRepository の EF Core 実装。
+/// </summary>
+public sealed class RegistrationRepository(RegistrationsDbContext dbContext) : IRegistrationRepository
+{
+    public async Task<Registration?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Registrations.FindAsync([id], cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Registration>> GetByEventIdAsync(Guid eventId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Registrations
+            .Where(r => r.EventId == eventId && r.Status != RegistrationStatus.Cancelled)
+            .OrderBy(r => r.Status)
+            .ThenBy(r => r.RegisteredAt)
+            .ThenBy(r => r.Id)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> CountConfirmedByEventIdAsync(Guid eventId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Registrations
+            .CountAsync(r => r.EventId == eventId && r.Status == RegistrationStatus.Confirmed, cancellationToken);
+    }
+
+    public async Task<bool> HasActiveRegistrationAsync(Guid eventId, string normalizedEmail, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Registrations
+            .AnyAsync(r => r.EventId == eventId
+                        && r.Email == normalizedEmail
+                        && r.Status != RegistrationStatus.Cancelled,
+                cancellationToken);
+    }
+
+    public async Task<Registration?> GetOldestWaitListedAsync(Guid eventId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Registrations
+            .Where(r => r.EventId == eventId && r.Status == RegistrationStatus.WaitListed)
+            .OrderBy(r => r.RegisteredAt)
+            .ThenBy(r => r.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Registration registration, CancellationToken cancellationToken = default)
+    {
+        await dbContext.Registrations.AddAsync(registration, cancellationToken);
+    }
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationsDbContext.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationsDbContext.cs
@@ -1,0 +1,25 @@
+using EventRegistration.Registrations.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace EventRegistration.Registrations.Infrastructure.Persistence;
+
+/// <summary>
+/// Registrations モジュールの DbContext。
+/// </summary>
+public sealed class RegistrationsDbContext(DbContextOptions<RegistrationsDbContext> options) : DbContext(options)
+{
+    public DbSet<Registration> Registrations => Set<Registration>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Registration>(entity =>
+        {
+            entity.HasKey(r => r.Id);
+            entity.Property(r => r.EventId).IsRequired();
+            entity.Property(r => r.ParticipantName).IsRequired();
+            entity.Property(r => r.Email).IsRequired();
+            entity.Property(r => r.Status).IsRequired();
+            entity.Property(r => r.RegisteredAt).IsRequired();
+        });
+    }
+}

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/RegistrationsModuleInfrastructureExtensions.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/RegistrationsModuleInfrastructureExtensions.cs
@@ -1,0 +1,29 @@
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Application.UseCases;
+using EventRegistration.Registrations.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventRegistration.Registrations.Infrastructure;
+
+/// <summary>
+/// Registrations モジュールの Infrastructure サービスを DI コンテナへ登録する拡張メソッド。
+/// </summary>
+public static class RegistrationsModuleInfrastructureExtensions
+{
+    /// <summary>
+    /// Registrations モジュールの DbContext、リポジトリ、ユースケースを登録する。
+    /// </summary>
+    public static IServiceCollection AddRegistrationsModuleInfrastructure(this IServiceCollection services)
+    {
+        services.AddDbContext<RegistrationsDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: "Registrations"));
+
+        services.AddScoped<IRegistrationRepository, RegistrationRepository>();
+        services.AddScoped<RegisterParticipantUseCase>();
+        services.AddScoped<CancelRegistrationUseCase>();
+        services.AddScoped<GetRegistrationsByEventUseCase>();
+
+        return services;
+    }
+}

--- a/src/tests/EventRegistration.Web.Tests/EventRegistration.Web.Tests.csproj
+++ b/src/tests/EventRegistration.Web.Tests/EventRegistration.Web.Tests.csproj
@@ -19,8 +19,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\EventRegistration.Web\EventRegistration.Web.csproj" />
     <ProjectReference Include="..\..\Modules\SharedKernel\EventRegistration.SharedKernel.Application\EventRegistration.SharedKernel.Application.csproj" />
+    <ProjectReference Include="..\..\Modules\Events\EventRegistration.Events.Domain\EventRegistration.Events.Domain.csproj" />
     <ProjectReference Include="..\..\Modules\Events\EventRegistration.Events.Application\EventRegistration.Events.Application.csproj" />
+    <ProjectReference Include="..\..\Modules\Events\EventRegistration.Events.Infrastructure\EventRegistration.Events.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Modules\Registrations\EventRegistration.Registrations.Domain\EventRegistration.Registrations.Domain.csproj" />
     <ProjectReference Include="..\..\Modules\Registrations\EventRegistration.Registrations.Application\EventRegistration.Registrations.Application.csproj" />
+    <ProjectReference Include="..\..\Modules\Registrations\EventRegistration.Registrations.Infrastructure\EventRegistration.Registrations.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/EventRegistration.Web.Tests/Integration/RegistrationIntegrationTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Integration/RegistrationIntegrationTests.cs
@@ -1,0 +1,200 @@
+using EventRegistration.Events.Domain;
+using EventRegistration.Events.Infrastructure.Persistence;
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Application.Services;
+using EventRegistration.Registrations.Application.UseCases;
+using EventRegistration.Registrations.Domain;
+using EventRegistration.Registrations.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventRegistration.Web.Tests.Integration;
+
+[TestClass]
+public sealed class RegistrationIntegrationTests
+{
+    private ServiceProvider _provider = null!;
+    private IServiceScope _scope = null!;
+    private RegisterParticipantUseCase _registerUseCase = null!;
+    private CancelRegistrationUseCase _cancelUseCase = null!;
+    private GetRegistrationsByEventUseCase _getRegistrationsUseCase = null!;
+    private EventsDbContext _eventsDb = null!;
+    private Guid _eventId;
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        var dbId = Guid.NewGuid().ToString();
+        var services = new ServiceCollection();
+
+        services.AddDbContext<EventsDbContext>(o =>
+            o.UseInMemoryDatabase($"Events-{dbId}"));
+        services.AddDbContext<RegistrationsDbContext>(o =>
+            o.UseInMemoryDatabase($"Registrations-{dbId}"));
+
+        services.AddScoped<IRegistrationRepository, RegistrationRepository>();
+        services.AddScoped<IEventCapacityChecker, TestEventCapacityChecker>();
+        services.AddScoped<RegisterParticipantUseCase>();
+        services.AddScoped<CancelRegistrationUseCase>();
+        services.AddScoped<GetRegistrationsByEventUseCase>();
+
+        _provider = services.BuildServiceProvider();
+        _scope = _provider.CreateScope();
+
+        _eventsDb = _scope.ServiceProvider.GetRequiredService<EventsDbContext>();
+        _registerUseCase = _scope.ServiceProvider.GetRequiredService<RegisterParticipantUseCase>();
+        _cancelUseCase = _scope.ServiceProvider.GetRequiredService<CancelRegistrationUseCase>();
+        _getRegistrationsUseCase = _scope.ServiceProvider.GetRequiredService<GetRegistrationsByEventUseCase>();
+
+        // テスト用イベント作成（定員 2 名）
+        var ev = Event.Create("テストイベント", "テスト用", DateTimeOffset.UtcNow.AddDays(7), 2);
+        _eventId = ev.Id;
+        _eventsDb.Events.Add(ev);
+        await _eventsDb.SaveChangesAsync();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _scope.Dispose();
+        _provider.Dispose();
+    }
+
+    [TestMethod]
+    public async Task Register_WithinCapacity_StatusIsConfirmed()
+    {
+        var result = await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(RegistrationStatus.Confirmed, result.Registration.Status);
+    }
+
+    [TestMethod]
+    public async Task Register_ExceedsCapacity_StatusIsWaitListed()
+    {
+        await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+        await _registerUseCase.ExecuteAsync(_eventId, "花子", "hanako@example.com");
+
+        var result = await _registerUseCase.ExecuteAsync(_eventId, "次郎", "jiro@example.com");
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(RegistrationStatus.WaitListed, result.Registration.Status);
+    }
+
+    [TestMethod]
+    public async Task Register_DuplicateActiveEmail_ReturnsFailure()
+    {
+        await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+
+        var result = await _registerUseCase.ExecuteAsync(_eventId, "太郎2", "taro@example.com");
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task Register_DuplicateEmailDifferentCase_ReturnsFailure()
+    {
+        await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+
+        var result = await _registerUseCase.ExecuteAsync(_eventId, "太郎2", "TARO@EXAMPLE.COM");
+
+        Assert.IsFalse(result.IsSuccess);
+    }
+
+    [TestMethod]
+    public async Task Register_AfterCancel_Succeeds()
+    {
+        var first = await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+        await _cancelUseCase.ExecuteAsync(first.Registration.Id);
+
+        var result = await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(RegistrationStatus.Confirmed, result.Registration.Status);
+    }
+
+    [TestMethod]
+    public async Task Register_NonExistentEvent_ReturnsFailure()
+    {
+        var result = await _registerUseCase.ExecuteAsync(Guid.NewGuid(), "太郎", "taro@example.com");
+
+        Assert.IsFalse(result.IsSuccess);
+    }
+
+    [TestMethod]
+    public async Task Cancel_ConfirmedWithWaitList_PromotesOldestWaitListed()
+    {
+        var r1 = await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+        await _registerUseCase.ExecuteAsync(_eventId, "花子", "hanako@example.com");
+        await _registerUseCase.ExecuteAsync(_eventId, "次郎", "jiro@example.com"); // WaitListed
+
+        var cancelResult = await _cancelUseCase.ExecuteAsync(r1.Registration.Id);
+
+        Assert.IsTrue(cancelResult.IsSuccess);
+        Assert.IsNotNull(cancelResult.PromotedRegistration);
+        Assert.AreEqual("jiro@example.com", cancelResult.PromotedRegistration.Email);
+        Assert.AreEqual(RegistrationStatus.Confirmed, cancelResult.PromotedRegistration.Status);
+    }
+
+    [TestMethod]
+    public async Task Cancel_WaitListedNoPromotion()
+    {
+        await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+        await _registerUseCase.ExecuteAsync(_eventId, "花子", "hanako@example.com");
+        var waitlisted = await _registerUseCase.ExecuteAsync(_eventId, "次郎", "jiro@example.com");
+
+        var cancelResult = await _cancelUseCase.ExecuteAsync(waitlisted.Registration.Id);
+
+        Assert.IsTrue(cancelResult.IsSuccess);
+        Assert.IsNull(cancelResult.PromotedRegistration);
+    }
+
+    [TestMethod]
+    public async Task Cancel_AlreadyCancelled_ReturnsFailure()
+    {
+        var r = await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+        await _cancelUseCase.ExecuteAsync(r.Registration.Id);
+
+        var result = await _cancelUseCase.ExecuteAsync(r.Registration.Id);
+
+        Assert.IsFalse(result.IsSuccess);
+    }
+
+    [TestMethod]
+    public async Task Cancel_NonExistentRegistration_ReturnsFailure()
+    {
+        var result = await _cancelUseCase.ExecuteAsync(Guid.NewGuid());
+
+        Assert.IsFalse(result.IsSuccess);
+    }
+
+    [TestMethod]
+    public async Task GetRegistrations_ExcludesCancelled()
+    {
+        var r = await _registerUseCase.ExecuteAsync(_eventId, "太郎", "taro@example.com");
+        await _registerUseCase.ExecuteAsync(_eventId, "花子", "hanako@example.com");
+        await _cancelUseCase.ExecuteAsync(r.Registration.Id);
+
+        var registrations = await _getRegistrationsUseCase.ExecuteAsync(_eventId);
+
+        Assert.AreEqual(1, registrations.Count);
+        Assert.AreEqual("hanako@example.com", registrations[0].Email);
+    }
+
+    /// <summary>
+    /// テスト用の IEventCapacityChecker 実装。EventsDbContext を直接参照する。
+    /// </summary>
+    private sealed class TestEventCapacityChecker(EventsDbContext eventsDbContext) : IEventCapacityChecker
+    {
+        public async Task<EventCapacityInfo?> GetEventCapacityInfoAsync(
+            Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var ev = await eventsDbContext.Events
+                .AsNoTracking()
+                .FirstOrDefaultAsync(e => e.Id == eventId, cancellationToken);
+
+            return ev is null ? null : new EventCapacityInfo(ev.Id, ev.Name, ev.Capacity);
+        }
+    }
+}

--- a/src/tests/EventRegistration.Web.Tests/Modules/Events/Domain/EventTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Events/Domain/EventTests.cs
@@ -1,0 +1,55 @@
+using EventRegistration.Events.Domain;
+
+namespace EventRegistration.Web.Tests.Modules.Events.Domain;
+
+[TestClass]
+public sealed class EventTests
+{
+    [TestMethod]
+    public void Create_ValidInputs_ReturnsEvent()
+    {
+        var ev = Event.Create("テストイベント", "説明", DateTimeOffset.UtcNow.AddDays(7), 10);
+
+        Assert.IsNotNull(ev);
+        Assert.AreNotEqual(Guid.Empty, ev.Id);
+        Assert.AreEqual("テストイベント", ev.Name);
+        Assert.AreEqual("説明", ev.Description);
+        Assert.AreEqual(10, ev.Capacity);
+    }
+
+    [TestMethod]
+    public void Create_NullName_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => Event.Create(null!, null, DateTimeOffset.UtcNow, 10));
+    }
+
+    [TestMethod]
+    public void Create_WhitespaceName_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => Event.Create("  ", null, DateTimeOffset.UtcNow, 10));
+    }
+
+    [TestMethod]
+    public void Create_ZeroCapacity_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => Event.Create("テスト", null, DateTimeOffset.UtcNow, 0));
+    }
+
+    [TestMethod]
+    public void Create_NegativeCapacity_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => Event.Create("テスト", null, DateTimeOffset.UtcNow, -1));
+    }
+
+    [TestMethod]
+    public void Create_NullDescription_SetsDescriptionToNull()
+    {
+        var ev = Event.Create("テスト", null, DateTimeOffset.UtcNow, 5);
+
+        Assert.IsNull(ev.Description);
+    }
+}

--- a/src/tests/EventRegistration.Web.Tests/Modules/Events/Infrastructure/EventsModuleInfrastructureTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Events/Infrastructure/EventsModuleInfrastructureTests.cs
@@ -1,0 +1,77 @@
+using EventRegistration.Events.Application.Repositories;
+using EventRegistration.Events.Application.UseCases;
+using EventRegistration.Events.Infrastructure;
+using EventRegistration.Events.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventRegistration.Web.Tests.Modules.Events.Infrastructure;
+
+[TestClass]
+public sealed class EventsModuleInfrastructureTests
+{
+    [TestMethod]
+    public void AddEventsModuleInfrastructure_RegistersDbContext()
+    {
+        var services = new ServiceCollection();
+
+        services.AddEventsModuleInfrastructure();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(EventsDbContext));
+        Assert.IsNotNull(descriptor);
+    }
+
+    [TestMethod]
+    public void AddEventsModuleInfrastructure_RegistersRepository()
+    {
+        var services = new ServiceCollection();
+
+        services.AddEventsModuleInfrastructure();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEventRepository));
+        Assert.IsNotNull(descriptor);
+        Assert.AreEqual(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [TestMethod]
+    public void AddEventsModuleInfrastructure_RegistersUseCases()
+    {
+        var services = new ServiceCollection();
+
+        services.AddEventsModuleInfrastructure();
+
+        Assert.IsNotNull(services.FirstOrDefault(d => d.ServiceType == typeof(CreateEventUseCase)));
+        Assert.IsNotNull(services.FirstOrDefault(d => d.ServiceType == typeof(GetEventByIdUseCase)));
+        Assert.IsNotNull(services.FirstOrDefault(d => d.ServiceType == typeof(GetAllEventsUseCase)));
+    }
+
+    [TestMethod]
+    public void AddEventsModuleInfrastructure_ReturnsSameServiceCollection()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddEventsModuleInfrastructure();
+
+        Assert.AreSame(services, result);
+    }
+
+    [TestMethod]
+    public async Task EventRepository_AddAndRetrieve_Works()
+    {
+        var services = new ServiceCollection();
+        services.AddEventsModuleInfrastructure();
+        // Use a unique DB name to avoid cross-test interference
+        services.AddDbContext<EventsDbContext>(o =>
+            o.UseInMemoryDatabase($"Events-{Guid.NewGuid()}"), ServiceLifetime.Scoped);
+        var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IEventRepository>();
+
+        var ev = EventRegistration.Events.Domain.Event.Create("テスト", "説明", DateTimeOffset.UtcNow, 10);
+        await repo.AddAsync(ev);
+
+        var retrieved = await repo.GetByIdAsync(ev.Id);
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual("テスト", retrieved.Name);
+    }
+}

--- a/src/tests/EventRegistration.Web.Tests/Modules/Events/Navigation/EventsNavigationExtensionsTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Events/Navigation/EventsNavigationExtensionsTests.cs
@@ -28,6 +28,7 @@ public sealed class EventsNavigationExtensionsTests
         var item = provider.GetServices<INavigationItem>().Single();
 
         Assert.AreEqual("イベント管理", item.Title);
+        Assert.AreEqual("/events", item.Href);
         Assert.AreEqual("Event", item.Icon);
         Assert.AreEqual("イベント", item.Group);
         Assert.AreEqual(100, item.Order);

--- a/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Domain/RegistrationTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Domain/RegistrationTests.cs
@@ -1,0 +1,122 @@
+using EventRegistration.Registrations.Domain;
+
+namespace EventRegistration.Web.Tests.Modules.Registrations.Domain;
+
+[TestClass]
+public sealed class RegistrationTests
+{
+    [TestMethod]
+    public void Create_WithConfirmedStatus_ReturnsRegistration()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト太郎", "test@example.com", RegistrationStatus.Confirmed);
+
+        Assert.IsNotNull(registration);
+        Assert.AreNotEqual(Guid.Empty, registration.Id);
+        Assert.AreEqual("テスト太郎", registration.ParticipantName);
+        Assert.AreEqual("test@example.com", registration.Email);
+        Assert.AreEqual(RegistrationStatus.Confirmed, registration.Status);
+        Assert.IsNull(registration.CancelledAt);
+    }
+
+    [TestMethod]
+    public void Create_WithWaitListedStatus_ReturnsRegistration()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト花子", "hanako@example.com", RegistrationStatus.WaitListed);
+
+        Assert.AreEqual(RegistrationStatus.WaitListed, registration.Status);
+    }
+
+    [TestMethod]
+    public void Create_EmailIsNormalized()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト", " Test@EXAMPLE.COM ", RegistrationStatus.Confirmed);
+
+        Assert.AreEqual("test@example.com", registration.Email);
+    }
+
+    [TestMethod]
+    public void Create_ParticipantNameIsTrimmed()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), " テスト太郎 ", "test@example.com", RegistrationStatus.Confirmed);
+
+        Assert.AreEqual("テスト太郎", registration.ParticipantName);
+    }
+
+    [TestMethod]
+    public void Create_NullParticipantName_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => Registration.Create(Guid.NewGuid(), null!, "test@example.com", RegistrationStatus.Confirmed));
+    }
+
+    [TestMethod]
+    public void Create_NullEmail_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => Registration.Create(Guid.NewGuid(), "テスト", null!, RegistrationStatus.Confirmed));
+    }
+
+    [TestMethod]
+    public void Cancel_ConfirmedRegistration_SetsCancelled()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.Confirmed);
+
+        registration.Cancel();
+
+        Assert.AreEqual(RegistrationStatus.Cancelled, registration.Status);
+        Assert.IsNotNull(registration.CancelledAt);
+    }
+
+    [TestMethod]
+    public void Cancel_WaitListedRegistration_SetsCancelled()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.WaitListed);
+
+        registration.Cancel();
+
+        Assert.AreEqual(RegistrationStatus.Cancelled, registration.Status);
+        Assert.IsNotNull(registration.CancelledAt);
+    }
+
+    [TestMethod]
+    public void Cancel_AlreadyCancelled_ThrowsInvalidOperationException()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.Confirmed);
+        registration.Cancel();
+
+        Assert.ThrowsException<InvalidOperationException>(() => registration.Cancel());
+    }
+
+    [TestMethod]
+    public void Confirm_WaitListedRegistration_SetsConfirmed()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.WaitListed);
+
+        registration.Confirm();
+
+        Assert.AreEqual(RegistrationStatus.Confirmed, registration.Status);
+    }
+
+    [TestMethod]
+    public void Confirm_ConfirmedRegistration_ThrowsInvalidOperationException()
+    {
+        var registration = Registration.Create(
+            Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.Confirmed);
+
+        Assert.ThrowsException<InvalidOperationException>(() => registration.Confirm());
+    }
+
+    [TestMethod]
+    public void NormalizeEmail_TrimsAndLowercases()
+    {
+        Assert.AreEqual("test@example.com", Registration.NormalizeEmail(" Test@EXAMPLE.COM "));
+    }
+}

--- a/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Infrastructure/RegistrationsModuleInfrastructureTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Infrastructure/RegistrationsModuleInfrastructureTests.cs
@@ -1,0 +1,56 @@
+using EventRegistration.Registrations.Application.Repositories;
+using EventRegistration.Registrations.Application.UseCases;
+using EventRegistration.Registrations.Infrastructure;
+using EventRegistration.Registrations.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventRegistration.Web.Tests.Modules.Registrations.Infrastructure;
+
+[TestClass]
+public sealed class RegistrationsModuleInfrastructureTests
+{
+    [TestMethod]
+    public void AddRegistrationsModuleInfrastructure_RegistersDbContext()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRegistrationsModuleInfrastructure();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(RegistrationsDbContext));
+        Assert.IsNotNull(descriptor);
+    }
+
+    [TestMethod]
+    public void AddRegistrationsModuleInfrastructure_RegistersRepository()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRegistrationsModuleInfrastructure();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IRegistrationRepository));
+        Assert.IsNotNull(descriptor);
+        Assert.AreEqual(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [TestMethod]
+    public void AddRegistrationsModuleInfrastructure_RegistersUseCases()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRegistrationsModuleInfrastructure();
+
+        Assert.IsNotNull(services.FirstOrDefault(d => d.ServiceType == typeof(RegisterParticipantUseCase)));
+        Assert.IsNotNull(services.FirstOrDefault(d => d.ServiceType == typeof(CancelRegistrationUseCase)));
+        Assert.IsNotNull(services.FirstOrDefault(d => d.ServiceType == typeof(GetRegistrationsByEventUseCase)));
+    }
+
+    [TestMethod]
+    public void AddRegistrationsModuleInfrastructure_ReturnsSameServiceCollection()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddRegistrationsModuleInfrastructure();
+
+        Assert.AreSame(services, result);
+    }
+}


### PR DESCRIPTION
﻿## 概要

Registrations モジュール（イベント参加登録・キャンセル・キャンセル待ち管理）の実装。
仕様: `docs/modules/registrations.md`

## 変更内容

### Events モジュール（Registrations の依存として最低限実装）
- **Domain**: `Event` エンティティ（Id, Name, Description, ScheduledAt, Capacity, CreatedAt）
- **Application**: `IEventRepository`、ユースケース（Create/GetById/GetAll）、ナビゲーション Href 更新（`/` → `/events`）
- **Infrastructure**: `EventsDbContext`（InMemory "Events"）、`EventRepository`、`AddEventsModuleInfrastructure()` DI 拡張

### Registrations モジュール（フル実装）
- **Domain**: `Registration` エンティティ、`RegistrationStatus` 列挙型（Confirmed/WaitListed/Cancelled）
- **Application**: `IRegistrationRepository`、`IEventCapacityChecker`（反腐敗層）、ユースケース（RegisterParticipant/CancelRegistration/GetRegistrationsByEvent）
- **Infrastructure**: `RegistrationsDbContext`（InMemory "Registrations"）、`RegistrationRepository`、`AddRegistrationsModuleInfrastructure()` DI 拡張

### Web プロジェクト
- `EventCapacityCheckerAdapter`: モジュール間アダプター（IEventCapacityChecker 実装）
- **Events ページ**: イベント一覧（/events）、作成（/events/create）、詳細（/events/{id}）
- **Registrations コンポーネント**: 参加登録フォーム、参加者一覧（イベント詳細画面内に組み込み）
- `Program.cs`: Infrastructure DI 登録追加

### ビジネスルール
- 定員チェック（Confirmed 数 < Capacity → Confirmed、以上 → WaitListed）
- 重複登録防止（同一イベント × メール、有効登録のみ）
- キャンセル待ち繰り上げ（RegisteredAt, Id 順で最古の WaitListed を Confirmed に）
- メールアドレス正規化（trim + lowercase）
- キャンセル後の再登録対応

### テスト（71 テスト全パス）
- ドメインテスト（Event, Registration エンティティ）
- インフラ DI テスト（Events, Registrations）
- 統合テスト（定員内登録、定員超過、重複防止、キャンセル繰り上げ等）

## アーキテクチャ

- Clean Architecture 準拠（Domain ← Application ← Infrastructure）
- モジュール間直接参照なし（CON-008 準拠）: `IEventCapacityChecker` を Registrations.Application に定義し、Web プロジェクトの `EventCapacityCheckerAdapter` で実装
- EF Core InMemory（`data-access-strategy.md` 準拠）