### PR TITLE
fix: Events/Registrations モジュールのレビュー指摘修正 (#11)

### DIFF
--- a/docs/ui-shell-design.md
+++ b/docs/ui-shell-design.md
@@ -297,7 +297,7 @@ public static class EventsNavigationExtensions
     {
         services.AddSingleton<INavigationItem>(new NavigationItem(
             Title: "イベント管理",
-            Href: "/", // プレースホルダー (将来 /events 等に差し替え)
+            Href: "/events",
             Icon: "Event",
             Group: "イベント",
             Order: 100,
@@ -313,7 +313,7 @@ public static class RegistrationsNavigationExtensions
     {
         services.AddSingleton<INavigationItem>(new NavigationItem(
             Title: "参加登録",
-            Href: "/", // プレースホルダー (将来 /registrations 等に差し替え)
+            Href: "/events",
             Icon: "HowToReg",
             Group: "参加者",
             Order: 200,
@@ -324,7 +324,7 @@ public static class RegistrationsNavigationExtensions
 ```
 
 - 各モジュールは `services.AddSingleton<INavigationItem>(new NavigationItem(...))` で **1 件以上の項目を Singleton 登録**する（GUD-002 / AC-002 / AC-008）。
-- 本 PR の Walking Skeleton 段階では、いずれのモジュールも `Href = "/"`（プレースホルダー）でルートへ向ける。`/events` / `/registrations` ページの実装は別 Issue で扱う。
+- `Events` / `Registrations` モジュールはいずれも `Href = "/events"` を指す（Registrations モジュールは独立した一覧ページを持たず、イベント詳細画面内のコンポーネントとして提供されるため、現状はイベント一覧へ誘導する）。
 - ライフタイム選定理由: ナビゲーション項目は **不変な静的メタデータ**であり、Singleton が最適（NFR-002）。
 
 ### 4.3 Shell 側の解決
@@ -497,7 +497,7 @@ dotnet test EventRegistration.sln
 
 ## 8. 既知の制約・今後の検討事項
 
-- **Href プレースホルダー**: `Events` / `Registrations` モジュールの `Href` はいずれも `/`（ホーム）に向いており、実際の専用ページは未実装。後続 Issue で `/events` / `/registrations` ページを追加した時点で各 `AddXxxModuleNavigation()` の `Href` を差し替える。
+- **ナビゲーション Href の現状**: `Events` / `Registrations` モジュールの `Href` はいずれも `/events`（イベント一覧）を指す。Registrations は独立ページを持たずイベント詳細内のコンポーネントとして実装されているため、専用ルート（例: `/registrations`）を追加する場合は別 Issue で扱う。
 - **テスト追加済み**: `src/tests/EventRegistration.Web.Tests/` に 33 件のユニットテストを追加（`IconResolver` / `NavigationMatchExtensions` / `NavigationItem` / 各モジュール DI 拡張等）。bUnit による UI レンダリングテスト・アーキテクチャテストは次フェーズ候補。
 - **ナビゲーション並び替えの再評価**: 現状は Razor テンプレートで毎レンダー実行。項目数が増えた場合は `OnInitialized` でフィールドキャッシュ化する。
 - **ダークモード対応**: `IsDarkMode` トグル UI とパレット切り替えは本スコープ外。

--- a/src/EventRegistration.Web/Components/Pages/Events/EventCreate.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/EventCreate.razor
@@ -80,9 +80,10 @@
                 return;
             }
 
+            var eventDateTime = _model.ScheduledDate.Value.Add(_model.ScheduledTime.Value);
             var scheduledAt = new DateTimeOffset(
-                _model.ScheduledDate.Value.Add(_model.ScheduledTime.Value),
-                TimeZoneInfo.Local.GetUtcOffset(DateTime.Now));
+                eventDateTime,
+                TimeZoneInfo.Local.GetUtcOffset(eventDateTime));
 
             var ev = await CreateEventUseCase.ExecuteAsync(
                 _model.Name!,

--- a/src/EventRegistration.Web/Components/Pages/Events/EventDetail.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/EventDetail.razor
@@ -46,7 +46,7 @@ else
         </MudItem>
         <MudItem xs="12" md="7">
             <MudText Typo="Typo.h5" Class="mb-2">参加者一覧</MudText>
-            <ParticipantList EventId="EventId" @ref="_participantList" />
+            <ParticipantList EventId="EventId" @ref="_participantList" OnCancelled="HandleCancelled" />
         </MudItem>
     </MudGrid>
 }
@@ -86,6 +86,12 @@ else
         {
             await _participantList.RefreshAsync();
         }
+        StateHasChanged();
+    }
+
+    private async Task HandleCancelled()
+    {
+        await LoadDataAsync();
         StateHasChanged();
     }
 }

--- a/src/EventRegistration.Web/Components/Pages/Events/RegistrationForm.razor
+++ b/src/EventRegistration.Web/Components/Pages/Events/RegistrationForm.razor
@@ -90,6 +90,8 @@
     private sealed class RegistrationFormModel
     {
         public string? ParticipantName { get; set; }
+
+        [System.ComponentModel.DataAnnotations.EmailAddress(ErrorMessage = "メールアドレスの形式が正しくありません。")]
         public string? Email { get; set; }
     }
 }

--- a/src/Modules/Registrations/EventRegistration.Registrations.Application/Navigation/RegistrationsNavigationExtensions.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Application/Navigation/RegistrationsNavigationExtensions.cs
@@ -15,7 +15,7 @@ public static class RegistrationsNavigationExtensions
     {
         services.AddSingleton<INavigationItem>(new NavigationItem(
             Title: "参加登録",
-            Href: "/", // プレースホルダー (将来 /registrations 等に差し替え)
+            Href: "/events",
             Icon: "HowToReg",
             Group: "参加者",
             Order: 200,

--- a/src/Modules/Registrations/EventRegistration.Registrations.Domain/Registration.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Domain/Registration.cs
@@ -24,6 +24,18 @@ public class Registration
         ArgumentException.ThrowIfNullOrWhiteSpace(participantName);
         ArgumentException.ThrowIfNullOrWhiteSpace(email);
 
+        if (status != RegistrationStatus.Confirmed && status != RegistrationStatus.WaitListed)
+        {
+            throw new ArgumentException(
+                "生成時のステータスは Confirmed または WaitListed のみ指定できます。",
+                nameof(status));
+        }
+
+        if (!IsValidEmail(email))
+        {
+            throw new ArgumentException("メールアドレスの形式が正しくありません。", nameof(email));
+        }
+
         return new Registration
         {
             Id = Guid.NewGuid(),
@@ -67,4 +79,18 @@ public class Registration
     /// </summary>
     public static string NormalizeEmail(string email) =>
         email.Trim().ToLowerInvariant();
+
+    private static bool IsValidEmail(string email)
+    {
+        var trimmed = email.Trim();
+        try
+        {
+            var addr = new System.Net.Mail.MailAddress(trimmed);
+            return addr.Address == trimmed;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/EventRegistration.Registrations.Infrastructure.csproj
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/EventRegistration.Registrations.Infrastructure.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationsDbContext.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationsDbContext.cs
@@ -21,8 +21,14 @@ public sealed class RegistrationsDbContext(DbContextOptions<RegistrationsDbConte
             entity.Property(r => r.Status).IsRequired();
             entity.Property(r => r.RegisteredAt).IsRequired();
 
-            // EventId + Email のユニーク制約（有効登録の重複防止）
-            entity.HasIndex(r => new { r.EventId, r.Email }).IsUnique();
+            // Cancelled 以外の有効登録に対する EventId + Email のユニーク制約。
+            // フィルター条件の "2" は RegistrationStatus.Cancelled の enum 値。
+            // NOTE: EF Core InMemory プロバイダーではフィルター付きインデックスは実効しないため、
+            //       アプリケーション層 (RegisterParticipantUseCase.HasActiveRegistrationAsync) の
+            //       事前チェックが主要な防御ライン。本定義は SQL Server 等の本番 DB 移行時の保護層。
+            entity.HasIndex(r => new { r.EventId, r.Email })
+                .HasFilter("[Status] <> 2")
+                .IsUnique();
         });
     }
 }

--- a/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationsDbContext.cs
+++ b/src/Modules/Registrations/EventRegistration.Registrations.Infrastructure/Persistence/RegistrationsDbContext.cs
@@ -20,6 +20,9 @@ public sealed class RegistrationsDbContext(DbContextOptions<RegistrationsDbConte
             entity.Property(r => r.Email).IsRequired();
             entity.Property(r => r.Status).IsRequired();
             entity.Property(r => r.RegisteredAt).IsRequired();
+
+            // EventId + Email のユニーク制約（有効登録の重複防止）
+            entity.HasIndex(r => new { r.EventId, r.Email }).IsUnique();
         });
     }
 }

--- a/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Domain/RegistrationTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Domain/RegistrationTests.cs
@@ -115,6 +115,27 @@ public sealed class RegistrationTests
     }
 
     [TestMethod]
+    public void Create_InvalidEmailFormat_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => Registration.Create(Guid.NewGuid(), "テスト", "invalid-email", RegistrationStatus.Confirmed));
+    }
+
+    [TestMethod]
+    public void Create_ValidEmail_DoesNotThrow()
+    {
+        var registration = Registration.Create(Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.Confirmed);
+        Assert.IsNotNull(registration);
+    }
+
+    [TestMethod]
+    public void Create_CancelledStatus_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => Registration.Create(Guid.NewGuid(), "テスト", "test@example.com", RegistrationStatus.Cancelled));
+    }
+
+    [TestMethod]
     public void NormalizeEmail_TrimsAndLowercases()
     {
         Assert.AreEqual("test@example.com", Registration.NormalizeEmail(" Test@EXAMPLE.COM "));

--- a/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Infrastructure/RegistrationsModuleInfrastructureTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Infrastructure/RegistrationsModuleInfrastructureTests.cs
@@ -1,7 +1,9 @@
 using EventRegistration.Registrations.Application.Repositories;
 using EventRegistration.Registrations.Application.UseCases;
+using EventRegistration.Registrations.Domain;
 using EventRegistration.Registrations.Infrastructure;
 using EventRegistration.Registrations.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace EventRegistration.Web.Tests.Modules.Registrations.Infrastructure;
@@ -52,5 +54,26 @@ public sealed class RegistrationsModuleInfrastructureTests
         var result = services.AddRegistrationsModuleInfrastructure();
 
         Assert.AreSame(services, result);
+    }
+
+    [TestMethod]
+    public void RegistrationsDbContext_HasUniqueFilteredIndexOnEventIdAndEmail()
+    {
+        var options = new DbContextOptionsBuilder<RegistrationsDbContext>()
+            .UseInMemoryDatabase(databaseName: $"index-test-{Guid.NewGuid()}")
+            .Options;
+
+        using var context = new RegistrationsDbContext(options);
+        var entityType = context.Model.FindEntityType(typeof(Registration));
+        Assert.IsNotNull(entityType);
+
+        var index = entityType.GetIndexes().SingleOrDefault(i =>
+            i.Properties.Count == 2 &&
+            i.Properties.Any(p => p.Name == nameof(Registration.EventId)) &&
+            i.Properties.Any(p => p.Name == nameof(Registration.Email)));
+
+        Assert.IsNotNull(index, "EventId + Email の複合インデックスが定義されていること");
+        Assert.IsTrue(index.IsUnique, "インデックスは IsUnique であること");
+        Assert.AreEqual("[Status] <> 2", index.GetFilter(), "Cancelled を除外するフィルターが設定されていること");
     }
 }

--- a/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Navigation/RegistrationsNavigationExtensionsTests.cs
+++ b/src/tests/EventRegistration.Web.Tests/Modules/Registrations/Navigation/RegistrationsNavigationExtensionsTests.cs
@@ -28,6 +28,7 @@ public sealed class RegistrationsNavigationExtensionsTests
         var item = provider.GetServices<INavigationItem>().Single();
 
         Assert.AreEqual("参加登録", item.Title);
+        Assert.AreEqual("/events", item.Href);
         Assert.AreEqual("HowToReg", item.Icon);
         Assert.AreEqual("参加者", item.Group);
         Assert.AreEqual(200, item.Order);


### PR DESCRIPTION
﻿﻿## 概要  Issue #11 で指摘された Events / Registrations モジュールの 6 項目の軽微な不具合・改善を修正する。  ## 修正項目  1. 「参加登録」ナビゲーションリンクを正しいパス /events に修正 2. `EventDetail.razor` で `ParticipantList` の `OnCancelled` コールバックを接続し、キャンセル後の残り枠を再計算 3. メールアドレスのサーバー側バリデーション（ドメイン層 + Blazor フォーム）を追加 4. `RegistrationsDbContext` に `EventId + Email` のユニークインデックスを追加 5. `Registration.Create()` のステータスを `Confirmed` / `WaitListed` に限定 6. `EventCreate.razor` の `DateTimeOffset` オフセットをイベント日時ベースで計算  ## 検証  - `dotnet build EventRegistration.sln` 成功（0 errors） - `dotnet test EventRegistration.sln` 全 80 件成功（追加テスト 4 件含む）  Closes #11 

<!-- lifecycle-state
feature: "Events/Registrations レビュー指摘修正"
entry_mode: "draft"
issue: 11
pr: 13
branch: "feature/issue-11-review-fixes"
plan_comment_url: ""
phase: 3
step: "3.11"
status: "WAITING_HUMAN"
last_agent: "Architect"
last_decision: "COMPLETE"
counters:
  spec_review: 0
  design_review: 0
  build_fail: 0
  code_review: 2
  completion_cycle: 1
  e2e_retry: 0
  doc_update: 1
updated_at: "2026-04-25T03:43:04Z"
-->