### PR TITLE
docs(skill): add cloud agent lifecycle workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,12 @@
 - .NET / C# コードは `dotnet-best-practices` に準拠する
 - 最新の .NET 10 / C# 14 / ASP.NET Core 10 / Blazor 10 の機能は `dotnet10` / `aspnetcore-blazor10` スキルで確認する
 
+### ライフサイクルスキルの使い分け
+
+`feature-lifecycle` スキルは GitHub Issue / PR を正本として使用する。
+`cloud-agent-lifecycle` スキルは GitHub Cloud Agent の readonly 制約下で、仕様・状態台帳・Agent 間ログ・PR 本文案を `.github/lifecycle/<work-id>/` 配下に保存する。
+ユーザーがどちらかのスキルを明示した場合は、その transport 方針を優先する。GitHub Cloud Agent 上で `gh` CLI または GitHub API が readonly かつユーザーがファイルベース運用を求めている場合は、`cloud-agent-lifecycle` を使用する。
+
 ## フェーズ 4: テスト
 
 | スキル | 用途 |

--- a/.github/skills/cloud-agent-lifecycle/SKILL.md
+++ b/.github/skills/cloud-agent-lifecycle/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: cloud-agent-lifecycle
+description: 'GitHub Cloud Agent の readonly GitHub CLI 制約下で feature-lifecycle を回すためのファイルベース運用スキル。Issue/PR への書き込みができない場合に、仕様・状態台帳・エージェント間ログ・PR 本文案をリポジトリ内ファイルとして管理する。'
+---
+
+# Cloud Agent Lifecycle スキル
+
+## 概要
+
+このスキルは、GitHub Cloud Agent で `gh` CLI または GitHub API が readonly として動作し、Issue / PR の作成・編集・コメント投稿ができない場合の代替運用を定義する。
+
+### 主要なポイント
+
+| 項目 | 内容 |
+|------|------|
+| 適用条件 | Issue / PR への書き込みができない Cloud Agent 実行環境 |
+| 状態の正本 | `.github/lifecycle/<work-id>/state.yaml` |
+| 仕様の正本 | `.github/lifecycle/<work-id>/spec.md` |
+| Agent 間ログ | `.github/lifecycle/<work-id>/log.md` |
+| GitHub 投稿 | Agent は行わず、必要な本文案を outbox に生成する |
+
+---
+
+## 適用条件
+
+以下のいずれかを満たす場合、このスキルを使用する:
+
+- GitHub Cloud Agent 上で `gh issue create/edit/comment` または `gh pr create/edit/comment` が失敗する
+- `gh auth status` や環境説明から GitHub CLI が readonly と判断できる
+- ユーザーが「Cloud Agent」「github cli readonly」「Issue に書き込めない」等を明示した
+
+ローカル VS Code 環境で GitHub 書き込みが可能な場合は、既存の `feature-lifecycle` と `github-flow` を通常どおり使用してよい。
+
+---
+
+## Agent と transport の責務分離
+
+Agent 定義は Product Manager / Developer / Reviewer などの役割と出力形式だけを持つ。GitHub に投稿するか、ローカルファイルへ保存するかは、このスキルの transport ルールで決める。
+
+| 責務 | 所有者 |
+|------|--------|
+| 仕様・設計・実装・レビュー・テスト判断 | 各 Agent |
+| 状態台帳の保存先 | `cloud-agent-lifecycle` |
+| Agent 出力の保存先 | `cloud-agent-lifecycle` |
+| GitHub 投稿予定本文の生成 | `cloud-agent-lifecycle` |
+| 実際の GitHub 投稿・PR 作成・マージ | 人間または write 権限を持つ仕組み |
+
+Orchestrator は、各 Agent の出力に含まれる構造化メタデータを読み取り、`state.yaml`、`log.md`、outbox を更新する。Agent 自身に GitHub Cloud Agent 固有の分岐を書かない。
+
+---
+
+## 基本方針
+
+GitHub の Issue / PR を状態ストアとして使わず、リポジトリ内のファイルを正本として扱う。
+
+| 従来の保存先 | Cloud Agent での保存先 |
+|-------------|------------------------|
+| SPEC Issue body | `.github/lifecycle/<work-id>/spec.md` |
+| Issue / PR コメント | `.github/lifecycle/<work-id>/log.md` |
+| Issue / PR body の lifecycle-state | `.github/lifecycle/<work-id>/state.yaml` |
+| 実装計画コメント | `.github/lifecycle/<work-id>/implementation-plan.md` |
+| PR 本文 | `.github/lifecycle/<work-id>/pull-request.md` |
+| GitHub 投稿待ち本文 | `.github/lifecycle/<work-id>/outbox/*.md` |
+
+`<work-id>` は、Issue 番号がある場合は `issue-<number>`、Issue 番号がない場合は `request-<yyyyMMddHHmm>-<slug>` とする。
+
+---
+
+## Cloud Agent フロー
+
+### エントリモード
+
+| モード | 起動条件 | Step 1.1 の挙動 |
+|--------|---------|----------------|
+| `cloud-new` | ユーザーが自然文で要件を指示 | Product Manager の出力を基に `spec.md` と Issue 作成用 outbox を生成 |
+| `cloud-draft` | ユーザーがドラフト Issue 番号を指定（例: `draft_issue: 123`） | 既存 Issue を readonly で参照できる場合は読み取り、`spec.md` と Issue 更新用 outbox を生成 |
+| `cloud-pr` | 既存 PR ブランチ上で起動 | `state.yaml` と差分から Phase 3 を復元 |
+
+### 共通出力ルール
+
+各 Agent の出力は、`feature-lifecycle/references/communication-protocol.md` と同じヘッダーと遷移メタデータを使用する。Cloud Agent では、その出力を GitHub コメントとして投稿せず、`log.md` に追記する。
+
+### Phase 1: 仕様策定
+
+1. Orchestrator は work-id を決定する。
+2. Product Manager は仕様書本文を出力する。
+3. Orchestrator は Product Manager の出力から `spec.md`、`state.yaml`、`log.md`、必要な outbox を作成または更新する。
+4. Reviewer は `spec.md` をレビューし、Orchestrator は結果を `log.md` に追記する。
+5. 仕様承認が必要な場合、Orchestrator は `state.yaml` の `status` を `WAITING_HUMAN` にする。
+
+### Phase 2: 設計・計画
+
+1. Architect は設計方針を出力し、Orchestrator は `design.md` に保存する。
+2. Developer は実装計画を出力し、Orchestrator は `implementation-plan.md` に保存する。
+3. Documentation は必要な docs 骨子を更新する。
+4. Reviewer は設計・計画・docs 骨子をレビューし、結果を `log.md` に追記する。
+
+### Phase 3: 実装
+
+1. Developer は Cloud Agent が作業中のブランチ上で実装する。`gh pr create` は実行しない。
+2. PR 本文案を `pull-request.md` に生成する。
+3. Developer は PR 本文案を出力し、Orchestrator は `pull-request.md` に保存する。
+4. 実装、テスト、docs 更新、レビュー、E2E 結果を `log.md` と `state.yaml` に記録する。
+5. Ready for Review、マージ、Issue コメント投稿は人間または別の write 権限を持つ仕組みが行う。
+
+---
+
+## GitHub 書き込みの扱い
+
+Cloud Agent モードでは、以下の操作を実行しない:
+
+- `gh issue create`
+- `gh issue edit`
+- `gh issue comment`
+- `gh pr create`
+- `gh pr edit`
+- `gh pr comment`
+- `gh pr merge`
+
+必要な投稿内容は `.github/lifecycle/<work-id>/outbox/` に Markdown として生成する。ファイル名は `NN-agent-step-target.md` の形式とする。
+
+```text
+.github/lifecycle/issue-42/outbox/
+  01-product-manager-step-1.1-issue-body.md
+  02-reviewer-step-1.2-issue-comment.md
+  03-developer-step-2.2-plan-comment.md
+  04-pr-body.md
+```
+
+---
+
+## 状態復元
+
+セッション開始時やコンテキスト喪失後は、次の順で状態を復元する:
+
+1. `.github/lifecycle/**/state.yaml` を探す。
+2. 対象 work-id が複数ある場合は、ユーザー指定の Issue / PR / ブランチに最も近いものを選ぶ。
+3. `state.yaml` の `phase`、`step`、`status`、`last_decision` を読み、次のアクションを決める。
+4. `log.md` の末尾を確認し、直近の Agent 出力と遷移メタデータを照合する。
+
+---
+
+## 参照リファレンス
+
+- `references/file-transport.md` — ファイルベースの通信・outbox ルール
+- `references/state-ledger.yaml.md` — Cloud Agent 用状態台帳スキーマ
+- `../feature-lifecycle/references/communication-protocol.md` — Agent 出力フォーマット
+- `../feature-lifecycle/references/state-transitions.md` — 状態遷移

--- a/.github/skills/cloud-agent-lifecycle/references/file-transport.md
+++ b/.github/skills/cloud-agent-lifecycle/references/file-transport.md
@@ -1,0 +1,97 @@
+# ファイルトランスポート
+
+## 概要
+
+このドキュメントは、GitHub Cloud Agent が Issue / PR へ書き込めない場合に、Agent 間の通信と GitHub 投稿予定内容をリポジトリ内ファイルで管理するためのルールを定義する。
+
+### 主要なポイント
+
+| 項目 | 内容 |
+|------|------|
+| 通信ログ | `.github/lifecycle/<work-id>/log.md` に追記する |
+| 投稿予定 | `.github/lifecycle/<work-id>/outbox/*.md` に保存する |
+| 状態更新 | `.github/lifecycle/<work-id>/state.yaml` を更新する |
+| 既存 GitHub コメント | readonly で取得できる場合のみ入力情報として読む |
+
+---
+
+## ディレクトリ構成
+
+```text
+.github/lifecycle/<work-id>/
+  spec.md
+  design.md
+  implementation-plan.md
+  pull-request.md
+  log.md
+  state.yaml
+  outbox/
+    NN-agent-step-target.md
+```
+
+`design.md`、`implementation-plan.md`、`pull-request.md` は、該当フェーズに到達した時点で作成する。
+
+---
+
+## log.md の形式
+
+`log.md` は append-only とし、既存エントリの意味を変える編集を行わない。誤りを訂正する場合は、新しいエントリとして訂正内容を追記する。
+
+````markdown
+## 2026-04-27T10:00:00Z — Product Manager — Step 1.1
+
+> **[Product Manager]** — Step 1.1: 仕様書作成
+> Phase 1 / レビューサイクル 1回目
+
+本文...
+
+```yaml
+# --- transition metadata ---
+agent: "Product Manager"
+phase: 1
+step: "1.1"
+review_cycle: 1
+decision: "DONE"
+next_step: "1.2"
+artifacts:
+  - ".github/lifecycle/issue-42/spec.md"
+```
+````
+
+---
+
+## outbox の形式
+
+GitHub に投稿したい内容は、投稿先ごとに outbox ファイルとして保存する。
+
+| 投稿予定先 | ファイル名例 |
+|-----------|--------------|
+| Issue body | `01-product-manager-step-1.1-issue-body.md` |
+| Issue comment | `02-reviewer-step-1.2-issue-comment.md` |
+| PR body | `04-pr-body.md` |
+| PR comment | `05-tester-step-3.7-pr-comment.md` |
+
+outbox ファイルの先頭には、投稿先メタデータを HTML コメントで記録する。
+
+```markdown
+<!-- agent-outbox
+target: "issue"
+target_number: 42
+operation: "comment"
+created_by: "Reviewer"
+created_at: "2026-04-27T10:15:00Z"
+-->
+
+> **[Reviewer]** — Step 1.2: 仕様レビュー
+> Phase 1 / レビューサイクル 1回目
+
+本文...
+```
+
+---
+
+## GitHub 投稿との関係
+
+Cloud Agent は outbox を作成するだけで、GitHub への投稿は行わない。投稿が必要な場合は、人間または write 権限を持つ GitHub Actions が outbox の内容を確認して実行する。
+
+投稿後も outbox ファイルは履歴として残してよい。投稿済み管理が必要な場合は、別コミットでファイル名に `.posted` を付けるか、`state.yaml` の `outbox_status` に記録する。

--- a/.github/skills/cloud-agent-lifecycle/references/state-ledger.yaml.md
+++ b/.github/skills/cloud-agent-lifecycle/references/state-ledger.yaml.md
@@ -1,0 +1,83 @@
+# Cloud Agent 状態台帳
+
+## 概要
+
+このドキュメントは、GitHub Cloud Agent モードで使用する状態台帳 `state.yaml` のスキーマを定義する。Issue / PR body に状態を埋め込まず、リポジトリ内ファイルを正本として扱う。
+
+### 主要なポイント
+
+| 項目 | 内容 |
+|------|------|
+| 保存先 | `.github/lifecycle/<work-id>/state.yaml` |
+| 更新者 | Orchestrator |
+| 復元キー | `work_id`, `issue`, `branch`, `pr` |
+| 遷移判断 | `phase`, `step`, `status`, `last_decision` |
+
+---
+
+## スキーマ
+
+```yaml
+work_id: "issue-42"
+feature: "イベント一覧の検索機能"
+entry_mode: "cloud-draft"
+transport: "repo-files"
+issue: 42
+pr:
+branch: "feature/42-event-search"
+artifacts:
+  spec: ".github/lifecycle/issue-42/spec.md"
+  design: ".github/lifecycle/issue-42/design.md"
+  implementation_plan: ".github/lifecycle/issue-42/implementation-plan.md"
+  pull_request: ".github/lifecycle/issue-42/pull-request.md"
+  log: ".github/lifecycle/issue-42/log.md"
+phase: 1
+step: "1.2"
+status: "ACTIVE"
+last_agent: "Product Manager"
+last_decision: "DONE"
+counters:
+  spec_review: 0
+  design_review: 0
+  build_fail: 0
+  code_review: 0
+  completion_cycle: 0
+  e2e_retry: 0
+  doc_update: 0
+outbox_status:
+  pending: 1
+  posted: 0
+updated_at: "2026-04-27T10:30:00Z"
+```
+
+---
+
+## フィールド定義
+
+| フィールド | 必須 | 説明 |
+|-----------|------|------|
+| `work_id` | はい | ライフサイクル作業単位の ID |
+| `feature` | はい | 機能の短い説明 |
+| `entry_mode` | はい | `cloud-new` / `cloud-draft` / `cloud-pr` |
+| `transport` | はい | Cloud Agent では `repo-files` 固定 |
+| `issue` | いいえ | 関連 Issue 番号。未作成の場合は空 |
+| `pr` | いいえ | 関連 PR 番号。Cloud Agent が取得できない場合は空 |
+| `branch` | いいえ | 作業ブランチ名 |
+| `artifacts` | はい | 仕様、設計、計画、ログなどのファイルパス |
+| `phase` | はい | 現在フェーズ |
+| `step` | はい | 現在ステップ |
+| `status` | はい | `ACTIVE` / `WAITING_HUMAN` / `BLOCKED` / `ENV_FAILED` / `COMPLETED` |
+| `last_agent` | はい | 最後に作業した Agent |
+| `last_decision` | いいえ | 最後の遷移キーワード |
+| `counters` | はい | 各レビュー・再試行カウンター |
+| `outbox_status` | いいえ | GitHub 投稿待ちファイルの状態 |
+| `updated_at` | はい | ISO 8601 形式の更新日時 |
+
+---
+
+## 更新ルール
+
+- Orchestrator は各ステップ完了後に `state.yaml` を更新する。
+- `log.md` に完了エントリを追記してから `state.yaml` を更新する。
+- `status: WAITING_HUMAN` の間は、自律的に次フェーズへ進まない。
+- GitHub 書き込み失敗は `AUTH_FAILED` として扱わず、Cloud Agent モードでは通常制約として `transport: repo-files` を維持する。

--- a/.github/skills/feature-lifecycle/SKILL.md
+++ b/.github/skills/feature-lifecycle/SKILL.md
@@ -7,6 +7,8 @@ description: '7 つのカスタムエージェント（Orchestrator / Product Ma
 
 Orchestrator エージェントが駆動する、機能開発の自律ワークフローを定義する。
 
+このスキルは GitHub Issue / PR を状態管理と Agent 間コミュニケーションの正本として使用する。リポジトリ内ファイルを正本にする運用を行う場合は、`cloud-agent-lifecycle` スキルを明示的に使用する。
+
 ---
 
 ## エージェント一覧


### PR DESCRIPTION
﻿## 概要
GitHub Cloud Agent の readonly 制約下でも feature lifecycle 相当のフローを回せるように、ファイルベース運用の `cloud-agent-lifecycle` スキルを追加します。

## 変更内容
- `cloud-agent-lifecycle` スキルを追加し、`.github/lifecycle/<work-id>/` 配下で仕様・状態台帳・Agent 間ログ・PR 本文案を管理する方針を定義
- file transport と state ledger のリファレンスを追加
- `feature-lifecycle` は GitHub Issue / PR を正本にすることを明記
- `copilot-instructions.md` に `feature-lifecycle` と `cloud-agent-lifecycle` の使い分けを追記

## 確認事項
- [x] `git diff --check` が成功する
- [x] 新規 Markdown ファイルの末尾空白を確認済み
- [x] 新規 Markdown ファイルのコードフェンス行数を確認済み
- [ ] アプリケーションのビルド・テストは未実行（skill / agent 定義のみの変更）